### PR TITLE
Added support for content-available flag

### DIFF
--- a/lib/apnagent/message.js
+++ b/lib/apnagent/message.js
@@ -78,6 +78,7 @@ function Message (agent, codec, opts) {
     // import badge/sound
     if (opts.aps.badge) this.badge(opts.aps.badge);
     if (opts.aps.sound) this.sound(opts.aps.sound);
+    if (opts.aps['content-available']) this.contentAvailable(opts.aps['content-available']);
 
     // import alert
     if (opts.aps.alert && 'string' === typeof opts.aps.alert) {
@@ -318,6 +319,33 @@ Message.prototype.sound = function (sound) {
   this.settings.sound = sound;
   return this;
 };
+
+
+/**
+ * ### .contentAvailable (bool)
+ *
+ * Set the content-available flag for content download
+ * push notifications
+ *
+ * ```js
+ * msg.contentAvailable(true);
+ * ```
+ *
+ * @param {Bool} sets content-available flag to 1 if true
+ * @returns {this} for chaining
+ * @api public
+ * @name contentAvailable
+ */
+
+Message.prototype.contentAvailable = function (contentAvailable) {
+  if (contentAvailable) {
+    this.settings['content-available'] = 1;
+  } else {
+    this.settings['content-available'] = undefined;
+  }
+  return this;
+};
+
 
 /*!
  * .serialize ()

--- a/test/message.js
+++ b/test/message.js
@@ -42,6 +42,28 @@ describe('Message', function () {
     });
   });
 
+  describe('.contentAvailable(true)', function () {
+    it('should set content-available flag', function () {
+      var msg = new Message()
+        , res = msg.contentAvailable(true);
+      msg.should
+        .have.property('settings')
+        .and.have.property('content-available', 1);
+      res.should.deep.equal(msg);
+    });
+  });
+
+  describe('.contentAvailable(false)', function () {
+    it('should set content-available flag to 0', function () {
+      var msg = new Message()
+        , res = msg.contentAvailable(false);
+      msg.should
+        .have.property('settings')
+        .and.not.have.property('content-available');
+      res.should.deep.equal(msg);
+    });
+  });
+
   describe('.sound()', function () {
     it('should set sound', function () {
       var msg = new Message()


### PR DESCRIPTION
Currently the library only supports alert, sound and badge keys in the aps object, but [Apple's specification](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW1) also allows for a content-available key to be set. This patch fixes that issue.
