### PR TITLE
Destroy the gateway connection on error, so reconnection works also when the connection is dropped instead of closed.

### DIFF
--- a/lib/apnagent/agent/live.js
+++ b/lib/apnagent/agent/live.js
@@ -154,6 +154,9 @@ Agent.prototype.connect = function (cb) {
   // emit errors;
   gateway.on('error', function (err) {
     debug('(gateway) error: %s', err.message || 'Unspecified Error');
+    if (self.gateway) {
+      self.gateway.destroy();
+    }
     self.emit('gateway:error', err);
   });
 


### PR DESCRIPTION
When an error occurs and the apns server drops the connection, sometimes the live agent does not reconnect correctly. Apparently the 'close' event is not fired when when the connection is dropped suddenly from the remote side.
I was able to reproduce this by sending lots of notifications to non-existing device tokens (and thus receiving error 8). Be careful when testing this though, at some point the server stopped accepting my connections :)

Because by design the apns server always closes the connection on error (see the [docs](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW4)), it is safe to destroy the gateway on our end when encountering an error. This results in the close event being fired and the reconnection being started.

I'm not sure, but I guess this is also the source of the problems in issue https://github.com/qualiancy/apnagent/issues/1, the behavior that is described there is exactly what I encountered when discovering this issue.
