### PR TITLE
Not adding an alert key to the aps if the alert is not set

### DIFF
--- a/lib/apnagent/message.js
+++ b/lib/apnagent/message.js
@@ -395,9 +395,10 @@ Message.prototype.serialize = function () {
   extend(payload.aps, this.settings);
 
   // copy over alert settings
-  if (Object.keys(this.aps).length === 1 && this.aps.body) {
+  var apsLength = Object.keys(this.aps).length;
+  if (apsLength === 1 && this.aps.body) {
     payload.aps.alert = this.aps.body;
-  } else {
+  } else if (apsLength > 0) {
     payload.aps.alert = {};
     extend(payload.aps.alert, this.aps);
   }

--- a/test/message.js
+++ b/test/message.js
@@ -199,6 +199,17 @@ describe('Message', function () {
       });
     });
 
+    it('should have no alert body when alert not specified', function() {
+      var msg = new Message();
+      msg.device('00').sound('default');
+      var json = msg.serialize();
+      json.payload.should.deep.equal({
+        aps: {
+          sound: 'default'
+        }
+      });
+    });
+
     it('should truncate when only alert body', function () {
       var msg = new Message();
 


### PR DESCRIPTION
When no alert is specified (mostly useful when sending content-available messages), the aps dictionary would still contain an alert key with an empty dictionary. This could lead to unexpected results in an app that expects the alert to be either absent or containing useful values.
This pull request fixes that.
