### PR TITLE
Extend MockAgent so it can simulate msg rejection on Apple side (err 8)

### DIFF
--- a/lib/apnagent/agent/mock.js
+++ b/lib/apnagent/agent/mock.js
@@ -20,7 +20,8 @@ var debug = require('sherlock')('apnagent:agent-mock')
 var Base = require('./base')
   , codecs = require('../codecs')
   , errors = require('../errors')
-  , util = require('../util');
+  , util = require('../util')
+  , Device = require('../device');
 
 /*!
  * Primary Export
@@ -43,6 +44,9 @@ module.exports = Mock;
 
 function Mock () {
   Base.call(this);
+
+  // Messages sent to these devices will be rejected with error 8 BAD_TOKEN
+  this.badDevices = []
 }
 
 /*!
@@ -114,11 +118,31 @@ Mock.prototype.connect = function (cb) {
     cb();
   });
 
+  function shouldBeRejected (msgJson) {
+    msgDevice = new Device(msgJson.deviceToken);
+    reject = false;
+    for (var i = 0; i < self.badDevices.length; i++) {
+      reject = self.badDevices[i].equal(msgDevice)
+    }
+    return reject;
+  }
+
   // data event is emitted for each message
   function emitter () {
     var json = this.read();
-    debug('(gateway) incoming message', json);
-    self.emit('mock:message', json);
+    
+    // Simulate message error at Apple side
+    if (shouldBeRejected(json)) {
+      var err = new errors.GatewayMessageError("Invalid token", {code: 8})
+      self.meta.gatewayError = err;
+
+      debug('(gateway) incoming message error', err.toJSON(false));
+      self.emit('message:error', err, json);
+      gateway.end();
+    } else {
+      debug('(gateway) incoming message', json);
+      self.emit('mock:message', json);
+    }
   }
 
   gateway.stream(0).on('readable', emitter);
@@ -187,6 +211,37 @@ Mock.prototype.close = function (cb) {
   this.connected = false;
   this.queue.pause();
   return this;
+};
+
+/**
+ * .setBadDevices ()
+ * 
+ * If, after setting tokens here, message is sent to one
+ * of these token, it'll result in error 8 "Invalid token".
+ * Connection then will be closed.
+ *
+ * Intended to be used by clients when testing their error 
+ * mitigation logics.
+ *
+ * @param {Array} Array of Device
+ * @name setBadDevices
+ * @api public
+ */
+Mock.prototype.setBadDevices = function (devices) {
+  // Validate input, crash early if smth is wrong -
+  // better than search for a bug somewhere deep in code
+  if (!(devices instanceof Array)) {
+    throw new Error('Parameter "devices" should be an array of Device');
+  } else {
+    for (var i = 0; i < devices.length; i++) {
+      if (!(devices[i] instanceof Device)) {
+        throw new Error('Parameter "devices" should be an array of Device')
+      }
+    }
+  }
+
+  // All good
+  this.badDevices = devices;
 };
 
 Mock.prototype._queueIterator = function (obj, next) {

--- a/test/agent.mock.js
+++ b/test/agent.mock.js
@@ -1,3 +1,5 @@
+var Device = require('../lib/apnagent/device');
+
 describe('MockAgent', function () {
   var live = function (fn) { return fn; };
 
@@ -37,5 +39,135 @@ describe('MockAgent', function () {
         agent.gateway.end();
       });
     });
+  });
+
+  describe('.setBadDevices()', function () {
+    it('should throw error when passing a string', function (done) {
+      var agent = new apnagent.MockAgent();
+      try {
+        agent.setBadDevices("a token");
+        false.should.be.ok("We should not get here");
+      } catch(err) {
+        err.should.be.an.instanceOf(Error);
+        done();
+      }
+    });
+
+    it('should throw error when passing an array of strings', function (done) {
+      var agent = new apnagent.MockAgent();
+      try {
+        agent.setBadDevices([ "a token", "another token" ]);
+        false.should.be.ok("We should not get here");
+      } catch(err) {
+        err.should.be.an.instanceOf(Error);
+        done();
+      }
+    });
+
+    it('should throw error when passing a single Device', function (done) {
+      var agent = new apnagent.MockAgent();
+      try {
+        agent.setBadDevices(new Device("aa bb cc"));
+        false.should.be.ok("We should not get here");
+      } catch(err) {
+        err.should.be.an.instanceOf(Error);
+        done();
+      }
+    });
+
+    it('should succeed when passing an array of Device', function (done) {
+      var agent = new apnagent.MockAgent();
+      agent.setBadDevices([ new Device("aa bb cc") ]);
+      done();
+    });
+  });
+
+  describe('.send()', function () {
+    var agent;
+    var token = "87DB0CC7384019AB17C8AC9A6C2415C59354117B4D78585074AA1497E37F7500";
+
+    var sendMessage = function () {
+      agent
+        .createMessage()
+        .device(token)
+        .alert("Bah")
+        .send();
+    };
+
+    beforeEach(function (done) {
+      agent = new apnagent.MockAgent();
+      agent.enable('sandbox');
+      agent.connect(function (err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+
+    it('should emit a mock:message event when message is sent', function (done) {
+      agent.once([ 'mock', 'message' ], function(msg) {
+        msg.should.have.property('payload').an('object');
+        msg.payload.should.have.property('aps').an('object');
+        msg.should.have.property('deviceToken').an.instanceOf(Buffer);
+
+        var sentDevice = new Device(token)
+          , receivedDevice = new Device(msg.deviceToken);
+
+        sentDevice.equal(receivedDevice).should.be.ok
+        
+        agent.once([ 'gateway', 'close' ], done);
+        agent.close();
+      });
+
+      sendMessage()
+    });
+
+    it('should emit a message:error when message is sent to a bad device', function (done) {
+      agent.setBadDevices([ new Device(token) ]);
+        
+      agent.once([ 'message', 'error' ], function(err, msg) {
+        err.should.be.instanceOf(Error);
+        err.should.have.property('code').and.be.equal(8);
+        err.should.have.property('name').and.be.equal('GatewayMessageError');
+        err.should.have.property('message').and.be.equal('Invalid token');
+
+        msg.should.have.property('payload').an('object');
+        msg.payload.should.have.property('aps').an('object');
+        msg.should.have.property('deviceToken').an.instanceOf(Buffer);
+
+        var sentDevice = new Device(token)
+          , receivedDevice = new Device(msg.deviceToken);
+
+        sentDevice.equal(receivedDevice).should.be.ok
+        done();
+      });
+
+      sendMessage();
+    });
+
+    it('should reconnect after message error is received', function (done) {
+      agent.setBadDevices([ new Device(token) ]);
+      agent.once([ 'gateway', 'reconnect' ], done);
+      sendMessage();
+    });
+    
+    it('should resend message after an error and reconnection', function (done) {
+      agent.setBadDevices([ new Device(token) ]);
+      agent.once([ 'gateway', 'reconnect' ], function(err, msg) {
+
+        // Reset bad devices, now message should pass just fine
+        agent.once([ 'mock', 'message' ], function (msg) {
+          msg.should.have.property('payload').an('object');
+          msg.payload.should.have.property('aps').an('object');
+          msg.should.have.property('deviceToken').an.instanceOf(Buffer);
+          done();  
+        });
+
+        agent.setBadDevices([]);
+        sendMessage();
+      });
+
+      sendMessage();
+    });
+
   });
 });


### PR DESCRIPTION
Other causes of rejected message should be prevented on `apnagent` side - such as serialisation problems, but `BAD_TOKEN` error is the only one that may cause the message to be rejected.

Having this is important to properly test error mitigation.
