### PR TITLE
Fix payload trim for unicode alert text

### DIFF
--- a/lib/apnagent/util.js
+++ b/lib/apnagent/util.js
@@ -22,18 +22,24 @@ var APNS_PORT = 2195
   , FEED_SANDBOX = 'feedback.sandbox.push.apple.com';
 
 /**
- * Trim a string to a specific length. It is
- * expected that the string is longer than len.
+ * Trim a string to a specific bytes length. It is
+ * expected that the string bytes is longer than len.
  *
  * @param {String} string to trim
- * @param {Number} number of characters to include.
+ * @param {Number} number of bytes to include.
  * @return {String}
  * @api public
  */
 
 exports.trim = function (str, len) {
-  var res = str.substr(0, len - 3);
-  res = res.substr(0, Math.min(res.length, res.lastIndexOf(' ')));
+  var origLen = Buffer.byteLength(str)
+    , expLen = len - 3
+    , words = str.split(' ')
+    , res = words.shift();
+
+  while (Buffer.byteLength(res + words[0]) < expLen - 2) {
+    res += ' ' + words.shift();
+  }
   return res + '...';
 };
 

--- a/test/message.js
+++ b/test/message.js
@@ -146,6 +146,14 @@ describe('Message', function () {
       , 'sending messages that are this long then you really'
       , 'need to understand what a notification is.'
     ].join(' ');
+    var longBodyUnicode = [
+        'Οσα συμβαίνουν στην Ουκρανία έχουν ανοίξει'
+      , 'μια εξαιρετικά ενδιαφέρουσα συζήτηση για το'
+      , 'κατά πόσον οδεύουμε προς μια νέα παγκόσμια γεωπολιτική'
+      , 'συγκυρία. Κάποιοι πιστεύουν ότι ο χαμένος διπολισμός'
+      , 'του Ψυχρού Πολέμου επανέρχεται, άλλοι θεωρούν ότι η'
+      , 'σημερινή Ρωσία δεν μπορεί να παίξει τον ρόλο.'
+    ].join(' ');
 
     it('should get payload when only alert body', function () {
       var msg = new Message();
@@ -239,6 +247,33 @@ describe('Message', function () {
       });
     });
 
+    it('should truncate when only alert body (unicode)', function () {
+      var msg = new Message();
+
+      msg
+        .device('feedface')
+        .set('custom', 'variable')
+        .alert('body', longBodyUnicode)
+        .badge(1);
+
+      var json = msg.serialize();
+
+      Buffer.byteLength(JSON.stringify(json.payload), msg.encoding)
+        .should.not.be.above(256);
+
+      json.payload.should.deep.equal({
+          custom: 'variable'
+        , aps: {
+              alert:
+                [ 'Οσα συμβαίνουν στην Ουκρανία έχουν ανοίξει'
+                , 'μια εξαιρετικά ενδιαφέρουσα συζήτηση για το'
+                , 'κατά πόσον οδεύουμε...'
+                ].join(' ')
+            , badge: 1
+          }
+      });
+    });
+
     it('should truncate for complex alert body', function () {
       var msg = new Message();
 
@@ -263,6 +298,36 @@ describe('Message', function () {
                     , 'this string really long so that it is truncated'
                     , 'when I attempt to convert it to a string. If you are'
                     , 'sending messages that are this...'
+                    ].join(' ')
+                , 'launch-image': 'img.png'
+              }
+            , badge: 1
+          }
+      });
+    });
+
+    it('should truncate for complex alert body (unicode)', function () {
+      var msg = new Message();
+
+      msg
+        .device('00')
+        .set('custom', 'variable')
+        .alert('body', longBodyUnicode)
+        .alert('launch-image', 'img.png')
+        .badge(1);
+
+      var json = msg.serialize();
+
+      Buffer.byteLength(JSON.stringify(json.payload), msg.encoding)
+        .should.not.be.above(256);
+
+      json.payload.should.deep.equal({
+          custom: 'variable'
+        , aps: {
+              alert: {
+                  body:
+                    [ 'Οσα συμβαίνουν στην Ουκρανία έχουν ανοίξει'
+                    , 'μια εξαιρετικά ενδιαφέρουσα συζήτηση για το...'
                     ].join(' ')
                 , 'launch-image': 'img.png'
               }


### PR DESCRIPTION
If APN payload size exceeds Apple's 256 bytes limit and alert.body contains Unicode string, it is not trimmed correctly resulting in payloads exceeding 256 bytes.
My commit fixes this bug. I have also created unit tests for this.
