### PR TITLE
Fixing some memory leaks on Agent reconnect

### DIFF
--- a/lib/apnagent/agent/live.js
+++ b/lib/apnagent/agent/live.js
@@ -51,34 +51,33 @@ function Agent () {
 inherits(Agent, Base);
 
 /**
- * .reconnect()
+ * ._reconnect()
  *
  * Establish the broken connection again
  *
- * @name reconnect
- * @api public
+ * @name _reconnect
+ * @api private
  */
 
-Agent.prototype.reconnect = function(){
-    var self = this
-        , gwe = self.meta.gatewayError
-        , pos = 0;
+Agent.prototype._reconnect = function(){
+  var self = this
+    , gwe = self.meta.gatewayError
+    , pos = 0;
 
-    if (gwe && 'undefined' !== typeof gwe.identifier) {
-        debug('(cache) since: %d', gwe.identifier);
-        self.cache.sinceId(gwe.identifier, function (obj, id) {
-            debug('(queue) push: %d', id);
-            self.queue.pushAt(pos++, obj);
-        });
-    }
-
-    debug('(gateway) reconnecting');
-    self.connect(function (err) {
-        if (err) return;
-        debug('(gateway) reconnected');
-        self.emit('gateway:reconnect');
+  if (gwe && 'undefined' !== typeof gwe.identifier) {
+    debug('(cache) since: %d', gwe.identifier);
+    self.cache.sinceId(gwe.identifier, function (obj, id) {
+      debug('(queue) push: %d', id);
+      self.queue.pushAt(pos++, obj);
     });
+  }
 
+  debug('(gateway) reconnecting');
+  self.connect(function (err) {
+    if (err) return;
+    debug('(gateway) reconnected');
+    self.emit('gateway:reconnect');
+  });
 };
 
 /**
@@ -146,7 +145,7 @@ Agent.prototype.connect = function (cb) {
     if (self.connected && recon) {
       debug('(gateway) disconnected - %s:%d', opts.host, opts.port);
       self.connected = false;
-      self.meta.timer = setTimeout(self.reconnect.bind(self), ms(delay));
+      self.meta.timer = setTimeout(self._reconnect.bind(self), ms(delay));
     } else {
       debug('(gateway) closed - %s:%d', opts.host, opts.port);
       self.connected = false;


### PR DESCRIPTION
Hi guys! Thanks for the great package.
But keeping open several (4.. 6) connections on a machine with ~ 500 Mb RAM makes a process (runed without forever) to fall after 5 .. 10 hrs. 
Looks like this fix solved the problem. I've also tried to comment the function in your style.

Well, here is pull request, and thank you again for your package.
