### PR TITLE
Adapted library and tests for new 2KB payload size

### DIFF
--- a/lib/apnagent/message.js
+++ b/lib/apnagent/message.js
@@ -407,8 +407,8 @@ Message.prototype.serialize = function () {
   var str = JSON.stringify(payload)
     , len = Buffer.byteLength(str, enc);
 
-  if (len > 256 && this.aps.body) {
-    var over = len - 256
+  if (len > 2048 && this.aps.body) {
+    var over = len - 2048
       , bodyLen = Buffer.byteLength(this.aps.body, enc)
       , body = bodyLen <= over
         ? null
@@ -423,7 +423,7 @@ Message.prototype.serialize = function () {
     } else {
       payload.aps.alert.body = body;
     }
-  } else if (len > 256) {
+  } else if (len > 2048) {
     throw new SE('Message too long.', null, ssf);
   }
 

--- a/test/message.js
+++ b/test/message.js
@@ -167,7 +167,7 @@ describe('Message', function () {
       var json = msg.serialize();
 
       Buffer.byteLength(JSON.stringify(json.payload), msg.encoding)
-        .should.not.be.above(256);
+        .should.not.be.above(2048);
 
       json.payload.should.deep.equal({
           custom: 'variable'
@@ -192,7 +192,7 @@ describe('Message', function () {
       var json = msg.serialize();
 
       Buffer.byteLength(JSON.stringify(json.payload), msg.encoding)
-        .should.not.be.above(256);
+        .should.not.be.above(2048);
 
       json.payload.should.deep.equal({
           custom: 'variable'
@@ -230,7 +230,7 @@ describe('Message', function () {
       var json = msg.serialize();
 
       Buffer.byteLength(JSON.stringify(json.payload), msg.encoding)
-        .should.not.be.above(256);
+        .should.not.be.above(2048);
 
       json.payload.should.deep.equal({
           custom: 'variable'
@@ -259,7 +259,7 @@ describe('Message', function () {
       var json = msg.serialize();
 
       Buffer.byteLength(JSON.stringify(json.payload), msg.encoding)
-        .should.not.be.above(256);
+        .should.not.be.above(2048);
 
       json.payload.should.deep.equal({
           custom: 'variable'
@@ -287,7 +287,7 @@ describe('Message', function () {
       var json = msg.serialize();
 
       Buffer.byteLength(JSON.stringify(json.payload), msg.encoding)
-        .should.not.be.above(256);
+        .should.not.be.above(2048);
 
       json.payload.should.deep.equal({
           custom: 'variable'
@@ -319,7 +319,7 @@ describe('Message', function () {
       var json = msg.serialize();
 
       Buffer.byteLength(JSON.stringify(json.payload), msg.encoding)
-        .should.not.be.above(256);
+        .should.not.be.above(2048);
 
       json.payload.should.deep.equal({
           custom: 'variable'


### PR DESCRIPTION
At WWDC 2014, Apple announced an increase of the payload limit from 256 bytes to 2 kilobytes. This new limit is now in effect on production APNS servers, and thus the library should use the new limit.
