### PR TITLE
Added device to metadata of mock error message

### DIFF
--- a/lib/apnagent/agent/mock.js
+++ b/lib/apnagent/agent/mock.js
@@ -136,7 +136,7 @@ Mock.prototype.connect = function (cb) {
     if (shouldBeRejected(json)) {
       var err = new errors.GatewayMessageError("Invalid token", {code: 8})
       self.meta.gatewayError = err;
-
+      json.meta = {"device": new Device(json.deviceToken)};
       debug('(gateway) incoming message error', err.toJSON(false));
       self.emit('message:error', err, json);
       gateway.end();


### PR DESCRIPTION
When using the mock agent, it's nice to also have the device info available in the reported error.