### PR TITLE
Enable TCP keepalives for early detection of severed tcp connections (issue #1)

### DIFF
--- a/lib/apnagent/agent/base.js
+++ b/lib/apnagent/agent/base.js
@@ -74,6 +74,7 @@ function Base () {
   this.set('expires', 0);
   this.enable('reconnect');
   this.set('reconnect delay', 3000);
+  this.set('keepalive delay', '5m');
   this.disable('sandbox');
 
   // internal storage

--- a/lib/apnagent/agent/live.js
+++ b/lib/apnagent/agent/live.js
@@ -99,7 +99,7 @@ Agent.prototype.connect = function (cb) {
     , opts = util.gatewayOptions(this)
     , recon = this.enabled('reconnect')
     , ttl = this.get('cache ttl')
-    , keepalive = ms(this.get('keepalive delay'))
+    , keepalive = ms(this.get('keepalive delay').toString())
     , gateway;
 
   // don't try to connect without credentials

--- a/lib/apnagent/agent/live.js
+++ b/lib/apnagent/agent/live.js
@@ -99,6 +99,7 @@ Agent.prototype.connect = function (cb) {
     , opts = util.gatewayOptions(this)
     , recon = this.enabled('reconnect')
     , ttl = this.get('cache ttl')
+    , keepalive = ms(this.get('keepalive delay'))
     , gateway;
 
   // don't try to connect without credentials
@@ -137,7 +138,9 @@ Agent.prototype.connect = function (cb) {
   });
 
   // enable tcp keepalive for early detection of severed tcp connections
-  gateway.setKeepAlive(true, 5 * 60 * 1000);
+  if (keepalive > 0) {
+    gateway.setKeepAlive(true, keepalive);
+  }
 
   // handle a disconnection
   gateway.on('close', function () {

--- a/lib/apnagent/agent/live.js
+++ b/lib/apnagent/agent/live.js
@@ -136,6 +136,9 @@ Agent.prototype.connect = function (cb) {
     }
   });
 
+  // enable tcp keepalive for early detection of severed tcp connections
+  gateway.setKeepAlive(true, 5 * 60 * 1000);
+
   // handle a disconnection
   gateway.on('close', function () {
     self.cache.pause();

--- a/lib/apnagent/agent/mock.js
+++ b/lib/apnagent/agent/mock.js
@@ -136,7 +136,7 @@ Mock.prototype.connect = function (cb) {
     if (shouldBeRejected(json)) {
       var err = new errors.GatewayMessageError("Invalid token", {code: 8})
       self.meta.gatewayError = err;
-      json.meta = {"device": new Device(json.deviceToken)};
+
       debug('(gateway) incoming message error', err.toJSON(false));
       self.emit('message:error', err, json);
       gateway.end();

--- a/lib/apnagent/agent/mock.js
+++ b/lib/apnagent/agent/mock.js
@@ -136,7 +136,7 @@ Mock.prototype.connect = function (cb) {
     if (shouldBeRejected(json)) {
       var err = new errors.GatewayMessageError("Invalid token", {code: 8})
       self.meta.gatewayError = err;
-
+      json.meta = {"device": new Device(json.deviceToken)};
       debug('(gateway) incoming message error', err.toJSON(false));
       self.emit('message:error', err, json);
       gateway.end();

--- a/lib/apnagent/feedback/base.js
+++ b/lib/apnagent/feedback/base.js
@@ -43,6 +43,7 @@ function Base () {
   EventEmitter.call(this, { delimeter: ':' });
   this.connected = false;
   this.set('interval', '30m');
+  this.set('keepalive delay', '5m');
   this.disable('sandbox');
 
   this.meta = {};

--- a/lib/apnagent/feedback/live.js
+++ b/lib/apnagent/feedback/live.js
@@ -50,6 +50,7 @@ Feedback.prototype.connect = function (cb) {
   var self = this
     , interval = this.get('interval')
     , opts = util.feedbackOptions(this)
+    , keepalive = ms(this.get('keepalive delay'))
     , feedback;
 
   // don't try to connect without credentials
@@ -91,7 +92,9 @@ Feedback.prototype.connect = function (cb) {
   });
 
   // enable tcp keepalive for early detection of severed tcp connections
-  feedback.setKeepAlive(true, 5 * 60 * 1000);
+  if (keepalive > 0) {
+    feedback.setKeepAlive(true, keepalive);
+  }
 
   // handle a disconnection (expected)
   feedback.on('close', function () {

--- a/lib/apnagent/feedback/live.js
+++ b/lib/apnagent/feedback/live.js
@@ -90,6 +90,9 @@ Feedback.prototype.connect = function (cb) {
     }
   });
 
+  // enable tcp keepalive for early detection of severed tcp connections
+  feedback.setKeepAlive(true, 5 * 60 * 1000);
+
   // handle a disconnection (expected)
   feedback.on('close', function () {
     self.feedback = null;

--- a/test/agent.live.js
+++ b/test/agent.live.js
@@ -29,6 +29,21 @@ describe('Agent', function () {
       agent.set('key file', key);
       agent.connect(function (err) {
         should.not.exist(err);
+        agent.get('keepalive delay').should.equal('5m');
+        agent.once([ 'gateway', 'close' ], done);
+        agent.close();
+      });
+    }));
+
+    it('should be able to connect when keepalive disabled', live(function (done) {
+      var agent = new apnagent.Agent();
+      agent.enable('sandbox');
+      agent.set('cert file', cert);
+      agent.set('key file', key);
+      agent.set('keepalive delay', 0);
+      agent.connect(function (err) {
+        should.not.exist(err);
+        agent.get('keepalive delay').should.equal(0);
         agent.once([ 'gateway', 'close' ], done);
         agent.close();
       });


### PR DESCRIPTION
Enabling TCP keepalives fixed issue #1 for us. In our case a firewall managed by our provider was silently dropping packets for TCP connections which had been idle for more than an hour. Packets could be seen piling up in the 'Send-Q' column of netstat in this case and notifications would be lost at some point when the TCP stack finally gave up and emitted an ETIMEDOUT error. TCP keepalives fool the firewall and prevent  the connection from becoming idle.